### PR TITLE
version 1.1.1

### DIFF
--- a/84em-gravity-forms-ai.php
+++ b/84em-gravity-forms-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: 84EM Gravity Forms Entry AI Analysis
  * Plugin URI: https://84em.com
  * Description: Analyzes Gravity Forms submissions using Claude AI and stores insights as markdown in entry meta
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: 84EM
  * Author URI: https://84em.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants
-define( 'EIGHTYFOUREM_GF_AI_VERSION', '1.1.0' );
+define( 'EIGHTYFOUREM_GF_AI_VERSION', '1.1.1' );
 define( 'EIGHTYFOUREM_GF_AI_FILE', __FILE__ );
 define( 'EIGHTYFOUREM_GF_AI_PATH', plugin_dir_path( __FILE__ ) );
 define( 'EIGHTYFOUREM_GF_AI_URL', plugin_dir_url( __FILE__ ) );

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the 84EM Gravity Forms Entry AI Analysis plugin will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2025-09-15
+
+### Added
+- Delete button in AI Analysis metabox to remove analysis data from entries
+- Confirmation dialog before deleting analysis to prevent accidental removal
+- Audit trail via entry notes when analysis is deleted
+- New AJAX handler `84em_gf_ai_delete_analysis` with proper permission checks
+- New action hook `84em_gf_ai_analysis_deleted` fired after deletion
+- Trash icon indicator for delete button with red color styling
+
+### Changed
+- Updated button layout in AI Analysis metabox to accommodate delete action
+- Enhanced security with `gravityforms_edit_entries` capability requirement for deletion
+
 ## [1.1.0] - 2025-09-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,13 @@ All PHP classes use the namespace `EightyFourEM\GravityFormsAI\` with PSR-4 auto
 
 1. **Entry Processing** (`includes/Core/EntryProcessor.php`)
    - Hooks into Gravity Forms entry detail sidebar via `gform_entry_detail_sidebar_middle`
-   - Provides manual analysis trigger
+   - Provides manual analysis trigger and delete functionality
    - Stores raw markdown in entry meta
    - Handles HTML export with client-side markdown conversion using Marked.js
    - Auto-includes all text fields when no mapping configured (smart defaults)
    - Falls back to global enable setting when form-specific setting not configured
+   - Delete button with confirmation prompt removes all analysis data
+   - Adds entry note when analysis is deleted for audit trail
 
 2. **API Integration** (`includes/Core/APIHandler.php`)
    - Manages Claude API communication using WordPress HTTP API
@@ -139,8 +141,9 @@ The plugin supports these models (defined in Settings.php):
 ## AJAX Actions
 
 All AJAX actions use nonce verification and capability checks:
-- `84em_gf_ai_analyze_entry` - Manual entry analysis trigger
+- `84em_gf_ai_analyze_entry` - Manual entry analysis trigger (requires `gravityforms_view_entries`)
 - `84em_gf_ai_download_html` - Generate HTML export
+- `84em_gf_ai_delete_analysis` - Delete AI analysis from entry (requires `gravityforms_edit_entries`)
 - `84em_gf_ai_save_field_mapping` - Save form field mappings
 - `84em_gf_ai_test_api` - Test API connection
 - `84em_gf_ai_get_log_details` - View detailed log entry

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ WordPress plugin that integrates Claude AI with Gravity Forms to provide intelli
 - 💬 Custom prompts per form or globally
 - 📥 View analysis report in new browser tab with client-side markdown rendering
 - 🔄 Manual analysis/re-analysis from entry detail page
+- 🗑️ Delete analysis with confirmation prompt and audit trail
 - ✨ Uses Marked.js for consistent markdown-to-HTML conversion
 
 ## Requirements
@@ -280,6 +281,12 @@ add_action('84em_gf_ai_analysis_failed', function($entry_id, $error, $form_id) {
     // Handle analysis failures
     // For example, log to external service, send alert, etc.
 }, 10, 3);
+
+// After analysis is deleted
+add_action('84em_gf_ai_analysis_deleted', function($entry_id) {
+    // Handle post-deletion tasks
+    // For example, clean up related data, notify systems, etc.
+}, 10, 1);
 ```
 
 ## Troubleshooting

--- a/includes/Core/APIHandler.php
+++ b/includes/Core/APIHandler.php
@@ -168,11 +168,11 @@ class APIHandler {
         // Replace variables in prompt
         $replacements = [
             '{form_data}'         => isset( $data['form_data'] ) ? $this->format_form_data( $data['form_data'] ) : '',
-            '{form_title}'        => isset( $data['form_title'] ) ? $data['form_title'] : '',
-            '{submitter_name}'    => isset( $data['submitter_name'] ) ? $data['submitter_name'] : '',
-            '{submitter_email}'   => isset( $data['submitter_email'] ) ? $data['submitter_email'] : '',
-            '{submitter_company}' => isset( $data['submitter_company'] ) ? $data['submitter_company'] : '',
-            '{submission_date}'   => isset( $data['submission_date'] ) ? $data['submission_date'] : current_time( 'mysql' ),
+            '{form_title}'        => $data['form_title'] ?? '',
+            '{submitter_name}'    => $data['submitter_name'] ?? '',
+            '{submitter_email}'   => $data['submitter_email'] ?? '',
+            '{submitter_company}' => $data['submitter_company'] ?? '',
+            '{submission_date}'   => $data['submission_date'] ?? wp_date( 'Y-m-d H:i:s' ),
         ];
 
         $message = str_replace(
@@ -291,7 +291,7 @@ class APIHandler {
                 'request'       => json_encode( $request_to_log ),
                 'response'      => $response_text,
                 'error_message' => $error_message,
-                'created_at'    => current_time( 'mysql' ),
+                'created_at'    => wp_date( 'Y-m-d H:i:s' ),
             ],
             [ '%d', '%d', '%s', '%s', '%s', '%s', '%s' ]
         );

--- a/includes/Core/EntryProcessor.php
+++ b/includes/Core/EntryProcessor.php
@@ -91,7 +91,7 @@ class EntryProcessor {
 
             // Save AI analysis as entry meta (raw markdown)
             gform_update_meta( $entry['id'], '84em_ai_analysis', $analysis_result );
-            gform_update_meta( $entry['id'], '84em_ai_analysis_date', current_time( 'mysql' ) );
+            gform_update_meta( $entry['id'], '84em_ai_analysis_date', wp_date( 'Y-m-d H:i:s' ) );
 
             // Fire action after successful analysis
             do_action( '84em_gf_ai_after_analysis', $entry['id'], $analysis_result, $form['id'] );
@@ -101,7 +101,7 @@ class EntryProcessor {
         else {
             // Log error in meta as well for consistency
             gform_update_meta( $entry['id'], '84em_ai_analysis_error', $result['error'] );
-            gform_update_meta( $entry['id'], '84em_ai_analysis_error_date', current_time( 'mysql' ) );
+            gform_update_meta( $entry['id'], '84em_ai_analysis_error_date', wp_date( 'Y-m-d H:i:s' ) );
 
             // Fire action when analysis fails
             do_action( '84em_gf_ai_analysis_failed', $entry['id'], $result['error'], $form['id'] );


### PR DESCRIPTION
This pull request introduces a new feature to the Gravity Forms Entry AI Analysis plugin: users can now delete AI analysis data from entries directly from the entry detail page. The update improves usability, security, and auditability, while also refactoring some date handling code for consistency. The main changes are grouped below:

### New AI Analysis Deletion Feature

* Added a "Delete" button to the AI Analysis metabox, styled with a trash icon and red color, allowing users to remove analysis data from entries. A confirmation dialog prevents accidental deletion. [[1]](diffhunk://#diff-2d28ed2c9d8eadf9a4702d226820ceac69a3e8f71a19ad7ae2b79b95b76577edL340-R354) [[2]](diffhunk://#diff-2d28ed2c9d8eadf9a4702d226820ceac69a3e8f71a19ad7ae2b79b95b76577edR397-R427)
* Implemented the AJAX handler `ajax_delete_analysis` in `EntryProcessor.php`, which checks permissions, deletes all related meta, adds an entry note for audit trail, and fires the new `84em_gf_ai_analysis_deleted` action hook. [[1]](diffhunk://#diff-2d28ed2c9d8eadf9a4702d226820ceac69a3e8f71a19ad7ae2b79b95b76577edR518-R557) [[2]](diffhunk://#diff-2d28ed2c9d8eadf9a4702d226820ceac69a3e8f71a19ad7ae2b79b95b76577edR27-R29)
* Updated documentation (`CHANGELOG.md`, `README.md`, `CLAUDE.md`) to describe the new deletion capability, permission requirements, and the audit trail via entry notes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R284-R289) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L42-R48) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L142-R146)

### Security and Permissions

* Enhanced security by requiring the `gravityforms_edit_entries` capability for deletion, ensuring only authorized users can remove analysis. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R21) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L142-R146) [[3]](diffhunk://#diff-2d28ed2c9d8eadf9a4702d226820ceac69a3e8f71a19ad7ae2b79b95b76577edR518-R557)

### UI Improvements

* Updated button layout in the AI Analysis metabox to accommodate the new delete action and improve responsiveness.

### Date Handling Consistency

* Replaced usage of `current_time('mysql')` with `wp_date('Y-m-d H:i:s')` for storing and logging timestamps, improving consistency and reliability across the plugin. [[1]](diffhunk://#diff-2d28ed2c9d8eadf9a4702d226820ceac69a3e8f71a19ad7ae2b79b95b76577edL94-R97) [[2]](diffhunk://#diff-2d28ed2c9d8eadf9a4702d226820ceac69a3e8f71a19ad7ae2b79b95b76577edL104-R107) [[3]](diffhunk://#diff-c691dee2cb58593b6a65e1f3e0af6e32fe74feb250bb89c5e3612caa8d8822d8L171-R175) [[4]](diffhunk://#diff-c691dee2cb58593b6a65e1f3e0af6e32fe74feb250bb89c5e3612caa8d8822d8L294-R294)

### Version Update

* Bumped plugin version to `1.1.1` in both the main plugin file and constant definition. [[1]](diffhunk://#diff-0309da45021dcbfec9fb4712fa6617a59c9eead1e68fc1ce33e8cd27ce10bbbfL6-R6) [[2]](diffhunk://#diff-0309da45021dcbfec9fb4712fa6617a59c9eead1e68fc1ce33e8cd27ce10bbbfL23-R23)